### PR TITLE
Add FastAPI service for CHIRPS precipitation history

### DIFF
--- a/gee_service/app/main.py
+++ b/gee_service/app/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+import ee
+
+# Initialize Earth Engine
+try:
+    ee.Initialize()
+except Exception:
+    ee.Authenticate()
+    ee.Initialize()
+
+app = FastAPI()
+
+@app.get("/history")
+def history(lat: float, lon: float, fecha_inicio: str, fecha_fin: str):
+    """Return precipitation history for a point."""
+    point = ee.Geometry.Point([lon, lat])
+    collection = (
+        ee.ImageCollection('UCSB-CHG/CHIRPS/DAILY')
+        .filterDate(fecha_inicio, fecha_fin)
+        .filterBounds(point)
+        .select('precipitation')
+    )
+    region = collection.getRegion(point, scale=1000).getInfo()
+    header = region[0]
+    data = [dict(zip(header, row)) for row in region[1:]]
+    return data


### PR DESCRIPTION
## Summary
- add FastAPI app initialized with Google Earth Engine
- implement `/history` endpoint to fetch CHIRPS precipitation series for a point and date range

## Testing
- `python -m py_compile gee_service/app/main.py && echo 'py_compile success'`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893e782bed08326bcd4b5906b5792f7